### PR TITLE
PLTCONN-1773: go build creates executable that can run in windows, bu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ sp -h
 ### Windows
 Install cli using the following command.
 ```shell
-$ go build -o "C:\Program Files\sp-cli\sp"
+$ go build -o "C:\Program Files\sp-cli\sp.exe"
 ```
 
 After that, add the following directory to the system PATH parameter. This will only need to be done the first time you install the cli.


### PR DESCRIPTION
…t is missing .exe from path

## Description
What is the intent of this change and why is it being made?
Update readme to include .exe extension on windows build step

## How Has This Been Tested?
What testing have you done to verify this change?
Re-build sp-cli locally on windows
