### PR TITLE
PLTCONN-1788: Use go releaser for publishing docker image and binaries

### DIFF
--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: 1.17
 
       - name: Test
-        run: make test
+        run: go test -v -count=1 ./...
 
       - name: Install
         run: make install

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  sp-cli:
+  connector-cli-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - '*'
 
 env:
   REF: ${{ github.event.inputs.tag || github.ref }}
@@ -21,7 +20,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME}}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REF: ${{ github.event.inputs.tag || github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+        
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME}}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ archives:
 
 dockers:
   - image_templates:
-    - sailpoint/connector-cli:0.0.1
+    - sailpoint/connector-cli:{{.Tag}}
     use: buildx
     dockerfile: Dockerfile
     build_flag_templates:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,24 @@
+project_name: connector-cli
+builds:
+  - env: [CGO_ENABLED=0]
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+dockers:
+  - image_templates:
+    - sailpoint/connector-cli:0.0.1
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN apk add --no-cache \
 ADD . /app
 WORKDIR /app
 
-# Copy cli binary to correct location
+# Copy cli to bin location
 RUN cp connector-cli /usr/local/bin/sp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apk add --no-cache \
         awscli \
     && rm -rf /var/cache/apk/*
 
-# Install sp cli
+# Add cli binary
 ADD . /app
 WORKDIR /app
-RUN go build .
-RUN cp sp-cli /usr/local/bin/sp
+
+# Copy cli binary to correct location
+RUN cp connector-cli /usr/local/bin/sp


### PR DESCRIPTION
## Description
Push release to gihubt tag and docker hub when a release tag is created

## How Has This Been Tested?
Tested by running all these set up from a forked version of the cli repo, pushing to my personal dockerhub account
![image](https://user-images.githubusercontent.com/42616890/185666460-f02f2c33-811b-47e7-9598-6d4faa7870b5.png)

